### PR TITLE
[fix] use Nuitka instead of pyinstaller

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,15 @@ jobs:
         python-version: '3.11'
         cache: 'pip' # dependencies cache
 
+    - name: Cache Nuitka dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/AppData/Local/Nuitka/Nuitka/Cache
+        key: ${{ runner.os }}-nuitka-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-nuitka-
+          
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -40,6 +49,7 @@ jobs:
         --standalone 
         --onefile 
         --windows-disable-console 
+        --assume-yes-for-downloads
         --plugin-enable=tk-inter 
         --windows-icon-from-ico=assets/SaveLC.ico 
         --output-filename=SaveLiveCaptions.exe 


### PR DESCRIPTION
[**Description**] To solve the malware report in #7 : (Arctic Wolf: Unsafe; Bkav Pro: W64.AIDetectMalware; SecureAge: Malicious; SentinelOne (Static ML) Static AI -Suspicious PE; Skyhigh (SWG): BehavesLike.Win64.Dropper.rc). The detections were false positives common to PyInstaller-packaged apps. 

[**Changes**]
Updated the README with security instructions.
Switched our build pipeline to Nuitka (a C-based compiler), which significantly reduces false alerts.

[**Summary**]
This PR addresses the malware false-positive report in #7 by switching the build engine and updating user documentation.