### PR TITLE
[chores] add onedir pyinstaller

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,20 +35,28 @@ jobs:
 
     - name: Build exe
       run: |
-        pyinstaller --clean --onefile --windowed --icon=assets/SaveLC.ico --name SaveLiveCaptions src/main.py  
+        # Onefile
+        pyinstaller --clean --onefile --windowed --icon=assets/SaveLC.ico --name SaveLiveCaptions_SingleFile src/main.py
+        
+        # Onedir
+        pyinstaller --clean --onedir --windowed --icon=assets/SaveLC.ico --name SaveLiveCaptions_Folder src/main.py  
 
     - name: Upload to Artifacts (for quick testing)
       uses: actions/upload-artifact@v4
       with:
-        name: savelivecaptions-exe
-        path: dist/SaveLiveCaptions.exe
+        name: SaveLiveCaptions_Builds
+        path: |
+          dist/SaveLiveCaptions_SingleFile.exe
+          dist/SaveLiveCaptions_Folder/
         retention-days: 7  
 
     - name: Create Release and Upload exe (only on tags)
       if: startsWith(github.ref, 'refs/tags/')  
       uses: softprops/action-gh-release@v2  
       with:
-        files: dist/savelivecaptions.exe
+        files: |
+          dist/SaveLiveCaptions_SingleFile.exe
+          dist/SaveLiveCaptions_Folder.zip
         tag_name: ${{ github.ref_name }}  
         name: Release ${{ github.ref_name }}
         body: |


### PR DESCRIPTION
[**Description**]
To address the malware false-positive reports in #7:

Flags: (Arctic Wolf: Unsafe; Bkav Pro: W64.AIDetectMalware; SecureAge: Malicious; SentinelOne: Static AI; Skyhigh: BehavesLike.Win64.Dropper.rc).

After testing Nuitka, I found it triggered even more AI-based flags due to its unfamiliar binary structure. Therefore, I am retaining PyInstaller but optimizing the distribution strategy to minimize these common false positives.

[**Changes**]
Dual-Build Workflow: * Updated GitHub Actions to generate both SingleFile (.exe) and Folder (.zip) versions. Provided the "Folder" version as a safer alternative for users experiencing "Dropper" or "Heuristic" flags.

[**Summary**]
This PR addresses the malware reports in #7 by introducing a dual-distribution system. By providing a folder-based version alongside the single executable, we bypass "Dropper" detections (like Skyhigh) while maintaining transparency through updated security documentation.